### PR TITLE
PG-1383 - Token Refresh and Session Management

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,10 @@ services:
       context: .
       args:
         GIT_TOKEN: ${GIT_TOKEN}
-        PIP_REQUIREMENTS: requirements.txt
+        PIP_REQUIREMENTS: requirements-local.txt
     ports:
       - "8200:8200"
+      - "8211:8211"
     entrypoint: python3
     command: /opt/bh/webapp/src/manage.py runserver 0.0.0.0:8200
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "8200:8200"
       # Uncomment to help development by enabling debug ports for debugpy
-      - "8211:8211"
+      # - "8211:8211"
     entrypoint: python3
     command: /opt/bh/webapp/src/manage.py runserver 0.0.0.0:8200
     volumes:
@@ -43,8 +43,8 @@ services:
         GIT_TOKEN: ${GIT_TOKEN}
         PIP_REQUIREMENTS: requirements-test.txt
     # Uncomment to help development by enabling debug ports for debugpy
-    ports:
-      - "8212:8212"
+    # ports:
+    #   - "8212:8212"
     command: bash -c "python -m pytest --cov --cov-report html:htmlcov --cov-report term -s && flake8 . && mypy src --show-error-codes"
     volumes:
       - ./:/opt/bh
@@ -59,6 +59,7 @@ services:
       DD_ENV: "${DD_ENV:-local}"
       DD_TRACE_AGENT_URL: http://datadog:8126
       DD_TRACE_ENABLED: "${DD_TRACE_ENABLED:-False}"
+      DJANGO_SETTINGS_MODULE: "community_app.settings"
 
   postgres:
     build: docker/postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
         PIP_REQUIREMENTS: requirements-local.txt
     ports:
       - "8200:8200"
+      # Uncomment to help development by enabling debug ports for debugpy
       - "8211:8211"
     entrypoint: python3
     command: /opt/bh/webapp/src/manage.py runserver 0.0.0.0:8200
@@ -41,6 +42,9 @@ services:
       args:
         GIT_TOKEN: ${GIT_TOKEN}
         PIP_REQUIREMENTS: requirements-test.txt
+    # Uncomment to help development by enabling debug ports for debugpy
+    ports:
+      - "8212:8212"
     command: bash -c "python -m pytest --cov --cov-report html:htmlcov --cov-report term -s && flake8 . && mypy src --show-error-codes"
     volumes:
       - ./:/opt/bh
@@ -52,6 +56,9 @@ services:
       AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
       AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
       GIT_TOKEN: ${GIT_TOKEN}
+      DD_ENV: "${DD_ENV:-local}"
+      DD_TRACE_AGENT_URL: http://datadog:8126
+      DD_TRACE_ENABLED: "${DD_TRACE_ENABLED:-False}"
 
   postgres:
     build: docker/postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,6 @@ services:
       DD_ENV: "${DD_ENV:-local}"
       DD_TRACE_AGENT_URL: http://datadog:8126
       DD_TRACE_ENABLED: "${DD_TRACE_ENABLED:-False}"
-      DJANGO_SETTINGS_MODULE: "community_app.settings"
 
   postgres:
     build: docker/postgres

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [tool:pytest]
 testpaths = webapp/test
+DJANGO_SETTINGS_MODULE = community_app.settings
 
 [coverage:run]
 source = webapp/src/community_app, webapp/src/big_health

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [tool:pytest]
 testpaths = webapp/test
-DJANGO_SETTINGS_MODULE = community_app.settings
 
 [coverage:run]
 source = webapp/src/community_app, webapp/src/big_health

--- a/webapp/requirements-local.txt
+++ b/webapp/requirements-local.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+debugpy==1.2.1

--- a/webapp/requirements-test.txt
+++ b/webapp/requirements-test.txt
@@ -1,4 +1,4 @@
--r requirements.txt
+-r requirements-local.txt
 
 coverage-badge==0.2.0
 coverage==4.5.1

--- a/webapp/src/big_health/services/community_app/service.py
+++ b/webapp/src/big_health/services/community_app/service.py
@@ -1,6 +1,6 @@
-from bh.entities import SQLEntity
+# from bh.entities import SQLEntity
 from bh.services.base_service import BaseService
-from bh.services.factory import Factory
+# from bh.services.factory import Factory
 
 
 class CommunityApp(BaseService):
@@ -9,22 +9,3 @@ class CommunityApp(BaseService):
     It will not be published anywhere and will not be exposed to any other service.
     It is only intended to be used as an interface between the community web app and external BH services.
     """
-
-    def validate_tokens(self, access_token: str = None, refresh_token: str = None) -> SQLEntity:
-        """Validate tokens provided. If access_token is None, attempt to refresh tokens.
-
-        Args:
-            access_token (str, optional): access token of the session. Defaults to None.
-            refresh_token (str, optional): refresh token of the session. Defaults to None.
-
-        Returns:
-            SQLEntity: the UserAccountAuthentication entity
-        """
-        authentication_service = Factory.create("UserAccountAuthentication", "1")
-
-        # if not access_token:
-            # Access token is expired, use refresh token to get new tokens
-        #    tokens = authentication_service.refresh_access_token(refresh_token=refresh_token)
-        #    access_token, refresh_token = tokens["access_token"], tokens["refresh_token"]
-
-        return authentication_service.find_with_tokens(access_token=access_token, refresh_token=refresh_token)

--- a/webapp/src/big_health/services/community_app/service.py
+++ b/webapp/src/big_health/services/community_app/service.py
@@ -1,6 +1,4 @@
-# from bh.entities import SQLEntity
 from bh.services.base_service import BaseService
-# from bh.services.factory import Factory
 
 
 class CommunityApp(BaseService):

--- a/webapp/src/big_health/services/community_app/service.py
+++ b/webapp/src/big_health/services/community_app/service.py
@@ -22,9 +22,9 @@ class CommunityApp(BaseService):
         """
         authentication_service = Factory.create("UserAccountAuthentication", "1")
 
-        if not access_token:
+        # if not access_token:
             # Access token is expired, use refresh token to get new tokens
-            tokens = authentication_service.refresh_access_token(refresh_token=refresh_token)
-            access_token, refresh_token = tokens["access_token"], tokens["refresh_token"]
+        #    tokens = authentication_service.refresh_access_token(refresh_token=refresh_token)
+        #    access_token, refresh_token = tokens["access_token"], tokens["refresh_token"]
 
         return authentication_service.find_with_tokens(access_token=access_token, refresh_token=refresh_token)

--- a/webapp/src/community_app/auth/middleware.py
+++ b/webapp/src/community_app/auth/middleware.py
@@ -1,22 +1,16 @@
 import logging
-
 from datetime import datetime, timedelta
-from django.conf import settings
-from django.contrib.auth import logout
-
-# from django.shortcuts import redirect
-from misago.users.models import AnonymousUser
 from typing import Optional
 
 from bh.core_utils.bh_exception import BHException
 from bh.services.factory import Factory
 from bh_settings import get_settings
-
+from django.conf import settings
+from django.contrib.auth import logout
+# from django.shortcuts import redirect
+from misago.users.models import AnonymousUser
 
 logger = logging.getLogger("CommunityMiddleware")
-
-# import debugpy
-# debugpy.listen(("0.0.0.0", 8211))
 
 
 class UserNotAuthenticated(BHException):

--- a/webapp/src/community_app/auth/middleware.py
+++ b/webapp/src/community_app/auth/middleware.py
@@ -15,20 +15,46 @@ from bh_settings import get_settings
 
 logger = logging.getLogger("CommunityMiddleware")
 
-#import debugpy
-#debugpy.listen(("0.0.0.0", 8211))
+# import debugpy
+# debugpy.listen(("0.0.0.0", 8211))
 
 
-def platgen_session_middleware(get_response):
-    # One-time configuration and initialization.
+class UserNotAuthenticated(BHException):
+    # The page or resource you were trying to access can not be loaded until
+    # you first log-in with a valid username and password.
+    STATUS_CODE = 401
+    SHOULD_ALERT = False
+
+
+class PlatformTokenMiddleware:
+    """
+    Custom middleware to support coupling Misago/Django user sessions to Platform sessions which are managed with
+    access_token and refresh_token cookies
+
+    This is a class-level implementation of the new-style Djanog middleware (https://docs.djangoproject.com/en/3.1/topics/http/middleware/)
+    """
+
     ACCESS_TOKEN = "access_token"
     REFRESH_TOKEN = "refresh_token"
 
-    def extract_tokens(request, *args, **kwargs) -> dict:
-        return dict(access_token=request.COOKIES.get(ACCESS_TOKEN), refresh_token=request.COOKIES.get(REFRESH_TOKEN))
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # One-time configuration and initialization.
 
-    def construct_cookie_domain_from_request_headers(request_headers: dict) -> Optional[str]:
-        """Construct a domain string for the cookies from request headers (specifically the Origin header).
+    def _extract_tokens(self, request) -> dict:
+        """
+        Construct a dict of access_token and refresh_token, from a request
+
+        Args:
+            request (WSGIRequest): The request
+        Returns:
+            dict: A dict of the form {access_token=aToken, refresh_token=anotherToken}
+        """
+        return dict(access_token=request.COOKIES.get(self.ACCESS_TOKEN), refresh_token=request.COOKIES.get(self.REFRESH_TOKEN))
+
+    def _construct_cookie_domain_from_request_headers(self, request_headers: dict) -> Optional[str]:
+        """
+        Construct a domain string for the cookies from request headers (specifically the Origin header).
 
         Args:
             request_headers (dict): the request headers
@@ -38,45 +64,59 @@ def platgen_session_middleware(get_response):
         """
         try:
             domain = ".".join(request_headers["host"].split(".")[1:])
+            # For local dev, strip port. Is resiliant to no port
+            domain = domain.split(":")[0]
             return "." + domain if domain else None
         except KeyError:
             return None
 
-    def middleware(request, *args, **kwargs):
+    def __call__(self, request):
+        """
+        Here we validate existence of an authentication entity but ONLY for non-admin users.
+        We must support admin users logging in with email, and not using Sleepio auth cookies.
+        If we don't have an authentication entity, OR we don't have an access_token (e.g. it's expired)
+        we attempt to refresh the tokens with refresh_token
+
+        If that fails, we log the user out and redirect to sleepio (TBD-PENDING)
+        If that suceeds, we update the tokens
+
+        It's important that this is placed after Misago's user middleware items in the MIDDLEWARE list in settings.py,
+        to ensure we have a user attached to the session, which allows us to log the user off prior to redirecting.
+
+        This is to avoid managing sessions directly, and using built-in behavior to log a user out.
+
+        If we have an authentication entity, we enrich the request to include the platform_user_id, which is used in
+        the social_auth_pipeline, fetch_user_account
+
+        Args:
+            request (WSGIRequest): The request
+        Returns:
+            response: The response
+        """
+
         # Code to be executed for each request before
         # the view (and later middleware) are called.
-
         cookies_updated = False
         authentication_entity = None
 
-        # Here we validate existence of an authentication entity but ONLY for non-admin users.
-        # We must support admin users logging in with email, and not using Sleepio auth cookies.
-        # If we don't have an authentication entity, OR we don't have an access_token (e.g. it's expired)
-        # we attempt to refresh the tokens with refresh_token
-        #
-        # If that fails, we log the user out and redirect to sleepio
-        # If that suceeds, we update the tokens
-        #
-        # It's important that this is placed after Misago's user middleware items, to ensure we have a
-        # user attached to the session, which allows us to log the user off prior to redirecting.
-        #
-        # This is to avoid managing sessions directly, and using built-in behavior to log a user out.
-        # If we have an authentication entity, we enrich the request to include the platform_user_id, which is used in
-        # the social_auth_pipeline, fetch_user_account
+        if hasattr(request, "user") and not request.user.is_superuser:
+            tokens = self._extract_tokens(request)
+            access_token, refresh_token = tokens.get(self.ACCESS_TOKEN), tokens.get(self.REFRESH_TOKEN)
 
-        if not request.user.is_superuser:
-            tokens = extract_tokens(request)
-            access_token, refresh_token = tokens.get(ACCESS_TOKEN), tokens.get(REFRESH_TOKEN)
             authentication_service = Factory.create("UserAccountAuthentication", "1")
+
             if access_token or refresh_token:
                 # TODO question, this works with either token. If we don't have a refresh token, this means we'll be redirected
                 # when it times out. Problem?
                 authentication_entity = authentication_service.find_with_tokens(access_token=access_token, refresh_token=refresh_token)
+
             if access_token is None or not authentication_entity:
                 try:
                     tokens = authentication_service.refresh_access_token(refresh_token=refresh_token)
-                    access_token, refresh_token = tokens.get(ACCESS_TOKEN), tokens.get(REFRESH_TOKEN)
+                    access_token, refresh_token = tokens.get(self.ACCESS_TOKEN), tokens.get(self.REFRESH_TOKEN)
                     authentication_entity = authentication_service.find_with_tokens(access_token=access_token, refresh_token=refresh_token)
+                    if not authentication_entity:
+                        raise UserNotAuthenticated
                     cookies_updated = True
                 except BHException as e:
                     logger.info(e)
@@ -91,16 +131,16 @@ def platgen_session_middleware(get_response):
 
         if authentication_entity:
             request._platform_user_id = authentication_entity.get("user_id")
-        response = get_response(request)
+
+        response = self.get_response(request)
 
         # Code to be executed for each request/response after
         # the view is called.
-
         if cookies_updated:
             clear_cookie_dt = datetime(year=1970, month=1, day=1)
-            domain = construct_cookie_domain_from_request_headers(request.headers)
+            domain = self._construct_cookie_domain_from_request_headers(request.headers)
             response.set_cookie(
-                ACCESS_TOKEN,
+                self.ACCESS_TOKEN,
                 access_token,
                 expires=(datetime.utcnow() + timedelta(seconds=get_settings("access_token_cookie_expiration_seconds")))
                 if access_token
@@ -111,7 +151,7 @@ def platgen_session_middleware(get_response):
             )
 
             response.set_cookie(
-                REFRESH_TOKEN,
+                self.REFRESH_TOKEN,
                 refresh_token,
                 expires=(datetime.utcnow() + timedelta(days=get_settings("refresh_token_cookie_expiration_days")))
                 if refresh_token
@@ -122,5 +162,3 @@ def platgen_session_middleware(get_response):
             )
 
         return response
-
-    return middleware

--- a/webapp/src/community_app/auth/middleware.py
+++ b/webapp/src/community_app/auth/middleware.py
@@ -15,9 +15,6 @@ from community_app.constants import COOKIE_NAME_ACCESS_TOKEN, COOKIE_NAME_REFRES
 
 logger = logging.getLogger("CommunityMiddleware")
 
-import debugpy
-debugpy.listen(("0.0.0.0", 8211))
-
 
 class UserNotAuthenticated(BHException):
     # The page or resource you were trying to access can not be loaded until

--- a/webapp/src/community_app/auth/middleware.py
+++ b/webapp/src/community_app/auth/middleware.py
@@ -1,23 +1,22 @@
 import logging
 
-from bh.core_utils.bh_exception import BHException
-# from bh.core_utils.request_context import RequestContext, CALL_ID, HEADERS
-from bh.services.factory import Factory
-# from bh_settings import get_settings
-
-
-# from community_app.auth.pipeline import extract_tokens
-
+from datetime import datetime, timedelta
 from django.conf import settings
 from django.contrib.auth import logout
+
 # from django.shortcuts import redirect
 from misago.users.models import AnonymousUser
+from typing import Optional
+
+from bh.core_utils.bh_exception import BHException
+from bh.services.factory import Factory
+from bh_settings import get_settings
 
 
 logger = logging.getLogger("CommunityMiddleware")
 
-# import debugpy
-# debugpy.listen(("0.0.0.0", 8211))
+#import debugpy
+#debugpy.listen(("0.0.0.0", 8211))
 
 
 def platgen_session_middleware(get_response):
@@ -27,6 +26,21 @@ def platgen_session_middleware(get_response):
 
     def extract_tokens(request, *args, **kwargs) -> dict:
         return dict(access_token=request.COOKIES.get(ACCESS_TOKEN), refresh_token=request.COOKIES.get(REFRESH_TOKEN))
+
+    def construct_cookie_domain_from_request_headers(request_headers: dict) -> Optional[str]:
+        """Construct a domain string for the cookies from request headers (specifically the Origin header).
+
+        Args:
+            request_headers (dict): the request headers
+
+        Returns:
+            Optional[str]: the domain string
+        """
+        try:
+            domain = ".".join(request_headers["host"].split(".")[1:])
+            return "." + domain if domain else None
+        except KeyError:
+            return None
 
     def middleware(request, *args, **kwargs):
         # Code to be executed for each request before
@@ -52,8 +66,7 @@ def platgen_session_middleware(get_response):
 
         if not request.user.is_superuser:
             tokens = extract_tokens(request)
-            access_token = tokens.get(ACCESS_TOKEN)
-            refresh_token = tokens.get(REFRESH_TOKEN)
+            access_token, refresh_token = tokens.get(ACCESS_TOKEN), tokens.get(REFRESH_TOKEN)
             authentication_service = Factory.create("UserAccountAuthentication", "1")
             if access_token or refresh_token:
                 # TODO question, this works with either token. If we don't have a refresh token, this means we'll be redirected
@@ -62,7 +75,7 @@ def platgen_session_middleware(get_response):
             if access_token is None or not authentication_entity:
                 try:
                     tokens = authentication_service.refresh_access_token(refresh_token=refresh_token)
-                    access_token, refresh_token = tokens["access_token"], tokens["refresh_token"]
+                    access_token, refresh_token = tokens.get(ACCESS_TOKEN), tokens.get(REFRESH_TOKEN)
                     authentication_entity = authentication_service.find_with_tokens(access_token=access_token, refresh_token=refresh_token)
                     cookies_updated = True
                 except BHException as e:
@@ -83,20 +96,29 @@ def platgen_session_middleware(get_response):
         # Code to be executed for each request/response after
         # the view is called.
 
-        # TODO make consistent with Sleepio
         if cookies_updated:
+            clear_cookie_dt = datetime(year=1970, month=1, day=1)
+            domain = construct_cookie_domain_from_request_headers(request.headers)
             response.set_cookie(
                 ACCESS_TOKEN,
                 access_token,
-                secure=settings.SESSION_COOKIE_SECURE or None,
-                httponly=settings.SESSION_COOKIE_HTTPONLY or None,
+                expires=(datetime.utcnow() + timedelta(seconds=get_settings("access_token_cookie_expiration_seconds")))
+                if access_token
+                else clear_cookie_dt,
+                domain=domain,
+                secure=get_settings("secure_cookies", True),
+                httponly=True,
             )
 
             response.set_cookie(
                 REFRESH_TOKEN,
                 refresh_token,
-                secure=settings.SESSION_COOKIE_SECURE or None,
-                httponly=settings.SESSION_COOKIE_HTTPONLY or None,
+                expires=(datetime.utcnow() + timedelta(days=get_settings("refresh_token_cookie_expiration_days")))
+                if refresh_token
+                else clear_cookie_dt,
+                secure=get_settings("secure_cookies", True),
+                domain=domain,
+                httponly=True,
             )
 
         return response

--- a/webapp/src/community_app/auth/middleware.py
+++ b/webapp/src/community_app/auth/middleware.py
@@ -1,17 +1,17 @@
 import logging
 
 from bh.core_utils.bh_exception import BHException
+# from bh.core_utils.request_context import RequestContext, CALL_ID, HEADERS
 from bh.services.factory import Factory
-from bh_settings import get_settings
+# from bh_settings import get_settings
 
 
-from community_app.auth.pipeline import extract_tokens
+# from community_app.auth.pipeline import extract_tokens
 
 from django.conf import settings
 from django.contrib.auth import logout
-from django.shortcuts import redirect
+# from django.shortcuts import redirect
 from misago.users.models import AnonymousUser
-from django.utils.deprecation import MiddlewareMixin
 
 
 logger = logging.getLogger("CommunityMiddleware")
@@ -25,42 +25,80 @@ def platgen_session_middleware(get_response):
     ACCESS_TOKEN = "access_token"
     REFRESH_TOKEN = "refresh_token"
 
-    def middleware(request):
+    def extract_tokens(request, *args, **kwargs) -> dict:
+        return dict(access_token=request.COOKIES.get("access_token"), refresh_token=request.COOKIES.get("refresh_token"))
+
+    def middleware(request, *args, **kwargs):
         # Code to be executed for each request before
         # the view (and later middleware) are called.
 
         cookies_updated = False
 
         # Here we validate existence of an authentication entity but ONLY for non-admin users.
+        # We must support admin users logging in with email, and not using Sleepio auth cookies.
         # If we don't have an authentication entity, OR we don't have an access_token (e.g. it's expired)
-        # we attempt to refresh the tokens with refresh_access_token
+        # we attempt to refresh the tokens with refresh_token
         #
         # If that fails, we log the user out and redirect to sleepio
         # If that suceeds, we update the tokens
-        if settings.SESSION_COOKIE_NAME in request.COOKIES and not request.user.is_superuser:
+        #
+        # It's important that this is placed after Misago's user middleware items, to ensure we have a
+        # user attached to the session, which allows us to log the user off prior to redirecting.
+        #
+        # This is to avoid managing sessions directly, and using built-in behavior to log a user out.
+        # If we have an authentication entity, we enrich the request to include the platform_user_id, which is used in
+        # the social_auth_pipeline, fetch_user_account
+
+        if not request.user.is_superuser:
             tokens = extract_tokens(request)
             access_token = tokens.get(ACCESS_TOKEN)
             refresh_token = tokens.get(REFRESH_TOKEN)
             authentication_service = Factory.create("UserAccountAuthentication", "1")
             authentication_entity = None
             if access_token or refresh_token:
+                # TODO question, this works with either token. If we don't have a refresh token, this means we'll be redirected
+                # when it times out. Problem?
                 authentication_entity = authentication_service.find_with_tokens(access_token=access_token, refresh_token=refresh_token)
             if access_token is None or not authentication_entity:
                 try:
+                    # TODO POC on calling via ClientGateway to leverage its cookie creation
+                    # TBD: How to parse response?
+                    # client_gateway_service = Factory.create("ClientGateway", "1")
+                    # result = None
+                    # with RequestContext() as rc:
+                    #     rc.attach(HEADERS, {"Cookie": f"refresh_token={refresh_token}"})
+                    #     result = client_gateway_service.proxy_service_call(
+                    #         service_name="UserAccountAuthentication",
+                    #         service_version="1",
+                    #         service_method="refresh_access_token",
+                    #     )
+                    #     logger.info(result)
+                    #     logger.info(rc)
+                    # logger.info(result)
+
                     tokens = authentication_service.refresh_access_token(refresh_token=refresh_token)
                     access_token, refresh_token = tokens["access_token"], tokens["refresh_token"]
+                    authentication_entity = authentication_service.find_with_tokens(access_token=access_token, refresh_token=refresh_token)
                     cookies_updated = True
                 except BHException as e:
-                    logger.debug(e)
-                    logout(request)
-                    request.user = AnonymousUser()
-                    return redirect(get_settings("sleepio_app_url"))
+                    logger.info(e)
+                    if settings.SESSION_COOKIE_NAME in request.COOKIES:
+                        logout(request)
+                        request.user = AnonymousUser()
+                    # TODO enable this when we have sleepio redirect URLS,
+                    #   and second level domain cookies working.
+                    #   Until then, this will always fire upon landing on the page
+                    #   because we won't have the cookies generated
+                    # return redirect(get_settings("sleepio_app_url"))
 
+        if authentication_entity:
+            request._platform_user_id = authentication_entity.get("user_id")
         response = get_response(request)
 
         # Code to be executed for each request/response after
         # the view is called.
 
+        # TODO make consistent with Sleepio
         if cookies_updated:
             response.set_cookie(
                 ACCESS_TOKEN,

--- a/webapp/src/community_app/auth/middleware.py
+++ b/webapp/src/community_app/auth/middleware.py
@@ -15,6 +15,9 @@ from community_app.constants import COOKIE_NAME_ACCESS_TOKEN, COOKIE_NAME_REFRES
 
 logger = logging.getLogger("CommunityMiddleware")
 
+import debugpy
+debugpy.listen(("0.0.0.0", 8211))
+
 
 class UserNotAuthenticated(BHException):
     # The page or resource you were trying to access can not be loaded until
@@ -82,7 +85,7 @@ class PlatformTokenMiddleware:
 
         if not access_token or not authentication_entity:
             tokens = authentication_service.refresh_access_token(refresh_token=refresh_token)
-            access_token, refresh_token = tokens.get(COOKIE_NAME_ACCESS_TOKEN), tokens.get(COOKIE_NAME_REFRESH_TOKEN)
+            access_token, refresh_token = tokens.get("access_token"), tokens.get("refresh_token")
             authentication_entity = authentication_service.find_with_tokens(access_token=access_token, refresh_token=refresh_token)
             if not authentication_entity:
                 raise UserNotAuthenticated

--- a/webapp/src/community_app/auth/middleware.py
+++ b/webapp/src/community_app/auth/middleware.py
@@ -1,0 +1,81 @@
+import logging
+
+from bh.core_utils.bh_exception import BHException
+from bh.services.factory import Factory
+from bh_settings import get_settings
+
+
+from community_app.auth.pipeline import extract_tokens
+
+from django.conf import settings
+from django.contrib.auth import logout
+from django.shortcuts import redirect
+from misago.users.models import AnonymousUser
+from django.utils.deprecation import MiddlewareMixin
+
+
+logger = logging.getLogger("CommunityMiddleware")
+
+# import debugpy
+# debugpy.listen(("0.0.0.0", 8211))
+
+
+def platgen_session_middleware(get_response):
+    # One-time configuration and initialization.
+    ACCESS_TOKEN = "access_token"
+    REFRESH_TOKEN = "refresh_token"
+
+    def middleware(request):
+        # Code to be executed for each request before
+        # the view (and later middleware) are called.
+
+        cookies_updated = False
+
+        # Here we validate existence of an authentication entity but ONLY for non-admin users.
+        # If we don't have an authentication entity, OR we don't have an access_token (e.g. it's expired)
+        # we attempt to refresh the tokens with refresh_access_token
+        #
+        # If that fails, we log the user out and redirect to sleepio
+        # If that suceeds, we update the tokens
+        if settings.SESSION_COOKIE_NAME in request.COOKIES and not request.user.is_superuser:
+            tokens = extract_tokens(request)
+            access_token = tokens.get(ACCESS_TOKEN)
+            refresh_token = tokens.get(REFRESH_TOKEN)
+            authentication_service = Factory.create("UserAccountAuthentication", "1")
+            authentication_entity = None
+            if access_token or refresh_token:
+                authentication_entity = authentication_service.find_with_tokens(access_token=access_token, refresh_token=refresh_token)
+            if access_token is None or not authentication_entity:
+                try:
+                    tokens = authentication_service.refresh_access_token(refresh_token=refresh_token)
+                    access_token, refresh_token = tokens["access_token"], tokens["refresh_token"]
+                    cookies_updated = True
+                except BHException as e:
+                    logger.debug(e)
+                    logout(request)
+                    request.user = AnonymousUser()
+                    return redirect(get_settings("sleepio_app_url"))
+
+        response = get_response(request)
+
+        # Code to be executed for each request/response after
+        # the view is called.
+
+        if cookies_updated:
+            response.set_cookie(
+                ACCESS_TOKEN,
+                access_token,
+                secure=settings.SESSION_COOKIE_SECURE or None,
+                httponly=settings.SESSION_COOKIE_HTTPONLY or None,
+            )
+
+            response.set_cookie(
+                REFRESH_TOKEN,
+                refresh_token,
+                secure=settings.SESSION_COOKIE_SECURE or None,
+                httponly=settings.SESSION_COOKIE_HTTPONLY or None,
+            )
+
+        return response
+
+    return middleware

--- a/webapp/src/community_app/constants.py
+++ b/webapp/src/community_app/constants.py
@@ -1,2 +1,2 @@
-COOKIE_NAME_ACCESS_TOKEN = "access_token"
-COOKIE_NAME_REFRESH_TOKEN = "refresh_token"
+COOKIE_NAME_ACCESS_TOKEN = "bh_access_token"
+COOKIE_NAME_REFRESH_TOKEN = "bh_refresh_token"

--- a/webapp/src/community_app/constants.py
+++ b/webapp/src/community_app/constants.py
@@ -1,0 +1,2 @@
+COOKIE_NAME_ACCESS_TOKEN = "access_token"
+COOKIE_NAME_REFRESH_TOKEN = "refresh_token"

--- a/webapp/src/community_app/settings.py
+++ b/webapp/src/community_app/settings.py
@@ -255,6 +255,7 @@ MIDDLEWARE = [
     "misago.socialauth.middleware.socialauth_providers_middleware",
     "misago.users.middleware.UserMiddleware",
     "misago.acl.middleware.user_acl_middleware",
+    "community_app.auth.middleware.platgen_session_middleware",
     "misago.core.middleware.ExceptionHandlerMiddleware",
     "misago.users.middleware.OnlineTrackerMiddleware",
     "misago.admin.middleware.AdminAuthMiddleware",

--- a/webapp/src/community_app/settings.py
+++ b/webapp/src/community_app/settings.py
@@ -268,7 +268,7 @@ SOCIAL_AUTH_STRATEGY = "social_django.strategy.DjangoStrategy"
 
 SOCIAL_AUTH_PIPELINE = (
     # Sleepio task to get user information
-    # Middleware task community_app.auth.middleware.platgen_session_middleware is responsible for
+    # Middleware task community_app.auth.middleware.PlatformTokenMiddleware is responsible for
     # authentication, and obtaining the platform user id
     "community_app.auth.pipeline.fetch_user_account",
 

--- a/webapp/src/community_app/settings.py
+++ b/webapp/src/community_app/settings.py
@@ -255,7 +255,7 @@ MIDDLEWARE = [
     "misago.socialauth.middleware.socialauth_providers_middleware",
     "misago.users.middleware.UserMiddleware",
     "misago.acl.middleware.user_acl_middleware",
-    "community_app.auth.middleware.platgen_session_middleware",
+    "community_app.auth.middleware.PlatformTokenMiddleware",
     "misago.core.middleware.ExceptionHandlerMiddleware",
     "misago.users.middleware.OnlineTrackerMiddleware",
     "misago.admin.middleware.AdminAuthMiddleware",

--- a/webapp/src/community_app/settings.py
+++ b/webapp/src/community_app/settings.py
@@ -267,9 +267,9 @@ ROOT_URLCONF = "community_app.urls"
 SOCIAL_AUTH_STRATEGY = "social_django.strategy.DjangoStrategy"
 
 SOCIAL_AUTH_PIPELINE = (
-    # Sleepio token tasks to get user information
-    "community_app.auth.pipeline.extract_tokens",
-    "community_app.auth.pipeline.validate_tokens",
+    # Sleepio task to get user information
+    # Middleware task community_app.auth.middleware.platgen_session_middleware is responsible for
+    # authentication, and obtaining the platform user id
     "community_app.auth.pipeline.fetch_user_account",
 
     # Steps required by social pipeline to work - don't delete those!

--- a/webapp/src/community_app/settings/default.yml
+++ b/webapp/src/community_app/settings/default.yml
@@ -5,3 +5,6 @@ django_staticfile_storage: storages.backends.s3boto3.S3Boto3Storage
 
 service_packages:
   - big_health.services.community_app.service.CommunityApp
+
+access_token_cookie_expiration_seconds: 1000
+refresh_token_cookie_expiration_days: 100

--- a/webapp/src/community_app/settings/local.yml
+++ b/webapp/src/community_app/settings/local.yml
@@ -14,5 +14,4 @@ db:
   port: 5432
   username: community
 
-# sleepio_app_url: https://sleepio-2184dea4-8e34-4f87-8451-b05fb2e5dd74.ngrok.io/
-sleepio_app_url: http://localhost:8100/
+sleepio_app_url: http://app.sleepio.localhost:8100/

--- a/webapp/src/community_app/settings/local.yml
+++ b/webapp/src/community_app/settings/local.yml
@@ -2,6 +2,8 @@ use_remote_dynamic_settings: false
 
 DEBUG: true
 
+secure_cookies: false  # Enable if using a proxy like ngrok
+
 django_file_storage: django.core.files.storage.FileSystemStorage
 django_staticfile_storage: django.contrib.staticfiles.storage.StaticFilesStorage
 

--- a/webapp/src/community_app/settings/local.yml
+++ b/webapp/src/community_app/settings/local.yml
@@ -12,4 +12,5 @@ db:
   port: 5432
   username: community
 
-sleepio_app_url: localhost:8100/
+# sleepio_app_url: https://sleepio-2184dea4-8e34-4f87-8451-b05fb2e5dd74.ngrok.io/
+sleepio_app_url: http://localhost:8100/

--- a/webapp/test/community_app/test_middleware.py
+++ b/webapp/test/community_app/test_middleware.py
@@ -55,7 +55,7 @@ def test_middleware_valid_access_token(mocks, get_request, get_response):
         "UserAccountAuthentication",
         "1",
         "refresh_access_token",
-        return_value={COOKIE_NAME_ACCESS_TOKEN: "foo1", COOKIE_NAME_REFRESH_TOKEN: "bar1"},
+        return_value={"access_token": "foo1", "refresh_token": "bar1"},
     ),
     ServiceCallMock(
         "UserAccountAuthentication",

--- a/webapp/test/community_app/test_middleware.py
+++ b/webapp/test/community_app/test_middleware.py
@@ -1,0 +1,130 @@
+from datetime import datetime, timedelta
+from unittest import mock
+from unittest.mock import Mock, call
+
+import pytest
+from bh.core_utils.bh_exception import BHException
+from bh.core_utils.test_utils import ServiceCallMock, mock_service_call
+from bh_settings import get_settings
+from django.conf import settings
+from django.test.client import RequestFactory
+from freezegun import freeze_time
+from misago.users.models import AnonymousUser
+
+from community_app.auth.middleware import PlatformTokenMiddleware
+
+
+@pytest.fixture
+def get_request():
+    request = RequestFactory().get("/")
+    request.headers = {}
+    request.headers["host"] = "foo.fake.com"
+    request.COOKIES = {}
+    return request
+
+
+@pytest.fixture
+def get_response():
+    return Mock()
+
+
+@mock_service_call(
+    ServiceCallMock(
+        "UserAccountAuthentication",
+        "1",
+        "find_with_tokens",
+        return_value={"user_id": "a_user"},
+    )
+)
+def test_middleware_valid_tokens(mocks, get_request, get_response):
+
+    #import debugpy
+    #debugpy.listen(("0.0.0.0", 8212))
+    #debugpy.wait_for_client()
+
+    get_request.user = AnonymousUser()
+    get_request.COOKIES["access_token"] = "foo"
+    get_request.COOKIES["refresh_tokne"] = "bar"
+
+    middleware = PlatformTokenMiddleware(get_response)
+    response = middleware(get_request)
+    assert get_request._platform_user_id == "a_user"
+    assert not response.method_calls
+
+
+@freeze_time(datetime(1970, 1, 7, 12, 0))
+@mock_service_call(
+    ServiceCallMock(
+        "UserAccountAuthentication",
+        "1",
+        "refresh_access_token",
+        return_value={"access_token": "foo1", "refresh_token": "bar1"},
+    ),
+    ServiceCallMock(
+        "UserAccountAuthentication",
+        "1",
+        "find_with_tokens",
+        return_value={"user_id": "a_user"},
+    ),
+)
+def test_middleware_refresh_tokens(mocks, get_request, get_response):
+    get_request.user = AnonymousUser()
+    get_request.COOKIES["access_token"] = None
+    get_request.COOKIES["refresh_token"] = "bar"
+
+    middleware = PlatformTokenMiddleware(get_response)
+    response = middleware(get_request)
+    assert get_request._platform_user_id == "a_user"
+
+    calls = [
+        call(
+            "access_token",
+            "foo1",
+            expires=(datetime(1970, 1, 7, 12, 0) + timedelta(seconds=get_settings("access_token_cookie_expiration_seconds"))),
+            domain=".fake.com",
+            secure=get_settings("secure_cookies", True),
+            httponly=True,
+        ),
+        call(
+            "refresh_token",
+            "bar1",
+            expires=(datetime(1970, 1, 7, 12, 0) + timedelta(days=get_settings("refresh_token_cookie_expiration_days"))),
+            domain=".fake.com",
+            secure=get_settings("secure_cookies", True),
+            httponly=True,
+        )
+    ]
+    response.set_cookie.assert_has_calls(calls)
+
+
+def raise_exception(*args, **kwargs):
+    class UserNotAuthenticated(BHException):
+        # The page or resource you were trying to access can not be loaded until
+        # you first log-in with a valid username and password.
+        STATUS_CODE = 401
+        SHOULD_ALERT = False
+
+    raise UserNotAuthenticated
+
+
+@mock_service_call(
+    ServiceCallMock(
+        "UserAccountAuthentication",
+        "1",
+        "refresh_access_token",
+        side_effect=raise_exception
+    ),
+)
+@mock.patch("community_app.auth.middleware.logout")
+def test_middleware_refresh_exception_logout(mocks, logout, get_request, get_response):
+    class UserMock:
+        name = "user mock"
+        is_superuser = False
+
+    get_request.user = UserMock()
+    get_request.COOKIES[settings.SESSION_COOKIE_NAME] = "session"
+    middleware = PlatformTokenMiddleware(get_response)
+    middleware(get_request)
+    assert get_request.user == AnonymousUser()
+    assert not hasattr(get_request, "_platform_user_id")
+    logout.assert_called_once


### PR DESCRIPTION
<!-- DELETE THIS BELOW -->
**Reminder to create the PR against this repository, and not the base fork of `rafalp/Misago`.**

### JIRA Ticket
<!--- Link the JIRA ticket here -->
https://bighealth.atlassian.net/browse/PG-1383

### Problem
<!--- A one sentence description of the problem this PR is solving -->
We must allow implicit refreshing, of Platform access_tokens and refresh_tokens from within Community.

### Solution
<!--- Explain your solution and give context -->
We define custom middleware that exists in the Django middleware stack after session and user creation. This allows us to use existing mechanisms to log the user out/end the session if we are unable to refresh tokens.

### Test Plan

#### Unit tests + Integration Tests
<!--- Which tests cover your work? -->
Unit Tests: tests/community_app/test_middleware
Integration Tests: N/A

#### Manual Tests
<!--- What is your monitoring plan? Expected impact? -->

### Rollout
<!--- Do your changes affect an API? Are they roll forward safe? Roll backward? Does client side need to be looped in? -->
To be easily tested, these changes depend on the integration of a button to navigate from Sleepio to Community

#### Related PRs
<!--- List all the PRs which are related to this one -->
https://github.com/sleepio/client-gateway-service-cluster/pull/52
