### PR TITLE
adding remote_manage for community

### DIFF
--- a/scripts/remote_manage.sh
+++ b/scripts/remote_manage.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+if [ "$#" == "0" ]; then
+    echo "Usage: remote_manage.sh <command>"
+    echo "Examples: (username, email and password all required!)"
+    echo "remote_manage.sh createsuperuser --noinput --username wbastian --email will.bastian@sleepio.com --password mainlypicturegivingfamily
+
+"
+    exit 1
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "jq is required. brew install jq
+    "
+    exit 1
+fi
+
+account=$(aws iam list-account-aliases --query AccountAliases[0] --output text)
+safe_accounts=(
+    bhdevacct
+    # bhciacct
+    # bhqaacct
+)
+if [[ ! " ${safe_accounts[@]} " =~ " ${account} " ]]; then
+    echo "The current AWS account is not in the approved list of safe accounts to run this in"
+    exit 1
+fi
+
+command="$@"
+
+echo $command
+
+community_web_function=$(aws lambda list-functions --query 'Functions[?contains(FunctionName,`community-app-web-`)][FunctionName]' --output text)
+
+output_file=$(mktemp)
+
+# --cli-binary-format raw-in-base64-out required for aws cli v2
+aws lambda invoke --function-name $community_web_function --payload "{\"manage\":\"${command}\"}" --cli-binary-format raw-in-base64-out $output_file 1>/dev/null
+
+cat $output_file | jq


### PR DESCRIPTION
allows us to invoke manage.py on lambda

<!-- DELETE THIS BELOW -->
**Reminder to create the PR against this repository, and not the base fork of `rafalp/Misago`.**

### JIRA Ticket
<!--- Link the JIRA ticket here -->
https://bighealth.atlassian.net/browse/PG-1423

### Problem
<!--- A one sentence description of the problem this PR is solving -->
We need the ability to bootstrap admin users in deployed environments

### Solution
<!--- Explain your solution and give context -->
Took @nmguse-bighealth 's remote_manage.sh and made relevant to community

### Test Plan

#### Unit tests + Integration Tests
<!--- Which tests cover your work? -->

#### Manual Tests
<!--- What is your monitoring plan? Expected impact? -->
Tested against community DEV deploy.

### Rollout
<!--- Do your changes affect an API? Are they roll forward safe? Roll backward? Does client side need to be looped in? -->

#### Related PRs
<!--- List all the PRs which are related to this one -->
